### PR TITLE
Use encodeURIComponent instead of encodeURI

### DIFF
--- a/lib/url-assembler-factory.js
+++ b/lib/url-assembler-factory.js
@@ -90,7 +90,7 @@ module.exports = function (request) {
     var chainable = this._chain();
     var previous = this.pathname;
     var symbol = ':' + key;
-    chainable.pathname = this.pathname.replace(symbol, encodeURI(value));
+    chainable.pathname = this.pathname.replace(symbol, encodeURIComponent(value));
     if (!strict && chainable.pathname === previous) {
       return chainable.query(key, value);
     }

--- a/test/110-instance-with-baseurl.js
+++ b/test/110-instance-with-baseurl.js
@@ -97,7 +97,7 @@ describe('an instance with a baseUrl', function () {
 
     it('should encode them in the final URL (with param)', function() {
       var expected = 'http://example.com'
-          + "/search/-_.!~*'()%20/;,%3F:@&=+$_abc_%E6%97%A5%E6%9C%AC%E8%AA%9E"
+          + "/search/-_.!~*'()%20%2F%3B%2C%3F%3A%40%26%3D%2B%24_abc_%E6%97%A5%E6%9C%AC%E8%AA%9E"
       myUrl = UrlAssembler('http://example.com')
           .segment('/search/:p')
           .param({


### PR DESCRIPTION
Hi @Floby,

first of all thanks for creating the node-url-assembler. I really like the API approach you have chosen!

We recently had a little problem: one of our third party system needs to have slashes in one of the URL parameters (which admittedly is not a very good idea, but what can you do?). Since the params method is using encodeURI they are not encoded at all, which breaks our routing. One could argue that, since a parameter is only a part of an URL, `param` should use [encodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) instead of [encodeURI](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI) which is usually used for full URLs.

To give a concrete example
```
UrlAssembler()
  .template('/users/:user')
  .param('user', 'benjamin/britten')
  .toString()
```
would currently result in `"/users/benjamin/britten"` which breaks any routing which only expects `/users/:users`.

With encodeURIComponent the above would results in `"/users/benjamin%252Fbritten"`.

Would you please kindly consider merging this? Thanks!

Regards
kyusu