### PR TITLE
Don't implicity declare key.

### DIFF
--- a/lib/url-assembler-factory.js
+++ b/lib/url-assembler-factory.js
@@ -98,7 +98,7 @@ module.exports = function (request) {
   };
 
   function _multiParam (chainable, hash, strict) {
-    for (key in hash) {
+    for (var key in hash) {
       chainable = chainable.param(key, hash[key], strict);
     }
     return chainable;


### PR DESCRIPTION
Implicit globals are bad, so instead explicity declare `var key` as
we do in other places.

All tests still pass.